### PR TITLE
Fix personal data page

### DIFF
--- a/metadata/page/page.incident-personal-data.json
+++ b/metadata/page/page.incident-personal-data.json
@@ -5,7 +5,6 @@
     {
       "$source": "@ministryofjustice/fb-components",
       "_id": "page.incident-personal-data--radios.auto_name__2",
-      "_isa": "",
       "_type": "radios",
       "classes": "govuk-radios--inline",
       "items": [


### PR DESCRIPTION
Remove the `isa` key from the personal-data page.

Was causing the following error:

`MergeError: No instance "" found, referenced by "page.incident-personal-data--radios.auto_name__2"`